### PR TITLE
Remove uniq from get tags call on document

### DIFF
--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -84,7 +84,7 @@ module Sablon
       end
 
       def get_tags(xml_node)
-        @parser.parse_fields(xml_node).map(&:expression).uniq
+        @parser.parse_fields(xml_node).map(&:expression)
       end
 
       private


### PR DESCRIPTION
Remove the `.uniq` call so we get EVERY tag, so we can do proper validation in our product.